### PR TITLE
モバイルの時の文字を入力するとズームになるのを解決しました

### DIFF
--- a/css/contact.css
+++ b/css/contact.css
@@ -64,10 +64,10 @@ body{
     -ms-box-sizing: border-box;
     box-sizing: border-box;
     width: 100%;
-    height: 36px;
+    height: 42px;
     border-radius: 5px;
     border: 1px solid #f1f1f1;
-    font-size: 1.2rem;
+    font-size: 1.6rem;
     padding-left: 16px;
     margin-top: 12px;
     margin-bottom: 24px;
@@ -81,10 +81,10 @@ body{
     -ms-box-sizing: border-box;
     box-sizing: border-box;
     width: 100%;
-    height: 36px;
+    height: 42px;
     border-radius: 5px;
     border: 1px solid #f1f1f1;
-    font-size: 1.2rem;
+    font-size: 1.6rem;
     padding-left: 16px;
     margin-top: 12px;
     margin-bottom: 24px;
@@ -102,7 +102,7 @@ body{
     height: 160px;
     border-radius: 5px;
     border: 1px solid #f1f1f1;
-    font-size: 1.2rem;
+    font-size: 1.6rem;
     padding: 16px;
     margin-top: 12px;
     margin-bottom: 24px;

--- a/css/headerandfooter.css
+++ b/css/headerandfooter.css
@@ -470,12 +470,13 @@
     .menu_search-keywords {
         background-color: #1E1E1E;
         border: 0;
-        height: 35px; /* 高さ40px */
+        height: 50px; /* 高さ40px */
         width: 86%;
         margin-left: 5%;
         margin-right: 5%;
-        padding: 0 2%;
+        padding: 0 4%;
         color: #ffffff;
+        font-size: 17px;
     }
 
 


### PR DESCRIPTION
モバイルの時、入力フォームの文字サイズが16px以上じゃないと、強制的にズームになるというiPhoneの仕様があったので、16pxになるように変更しました
headerandfooter.cssとcontact.cssをいじりました